### PR TITLE
Fix punctuation offset/scale breaking vertical text layout

### DIFF
--- a/components/BubbleLayer.tsx
+++ b/components/BubbleLayer.tsx
@@ -150,7 +150,22 @@ export const BubbleLayer: React.FC<BubbleLayerProps> = React.memo(({
                 if (entry.rotate) transforms.push(`rotate(${entry.rotate}deg)`);
                 if (entry.scale && entry.scale !== 100) transforms.push(`scale(${entry.scale / 100})`);
                 return transforms.length > 0
-                  ? <span key={i} style={{ display: 'inline-block', transform: transforms.join(' ') }}>{char}</span>
+                  ? (
+                      <span
+                        key={i}
+                        style={{
+                          display: 'inline-flex',
+                          width: '1em',
+                          height: '1em',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          transformOrigin: 'center',
+                          transform: transforms.join(' '),
+                        }}
+                      >
+                        {char}
+                      </span>
+                    )
                   : char;
               });
             })()

--- a/services/exportService.ts
+++ b/services/exportService.ts
@@ -971,7 +971,7 @@ export const compositeImageWithScreenshot = async (imageState: ImageState, optio
                     if (entry.rotate) transforms.push(`rotate(${entry.rotate}deg)`);
                     if (entry.scale && entry.scale !== 100) transforms.push(`scale(${entry.scale / 100})`);
                     return transforms.length > 0
-                        ? `<span style="display:inline-block;transform:${transforms.join(' ')}">${char}</span>`
+                        ? `<span style="display:inline-flex;width:1em;height:1em;align-items:center;justify-content:center;transform-origin:center;transform:${transforms.join(' ')}">${char}</span>`
                         : char;
                 }).join('');
             } else {


### PR DESCRIPTION
### Motivation

- Vertical punctuation adjustments (offset/rotate/scale) could collapse or misalign the vertical text flow when applied, breaking editor and screenshot layouts.
- The issue is caused by transformed inline elements not occupying a fixed grid cell in vertical writing mode, allowing layout to shift.
- The intent is to stabilize punctuation rendering so offsets and scales still apply without disturbing vertical text flow.

### Description

- Wrap transformed punctuation characters in a fixed `1em × 1em` `inline-flex` container with `transform-origin: center` in the editor rendering to preserve character grid alignment (`components/BubbleLayer.tsx`).
- Apply the same fixed-box HTML generation strategy to screenshot export so exported images match editor layout (`services/exportService.ts`).
- Keep existing transform behavior (`translateX`, `translateY`, `rotate`, `scale`) while ensuring visually consistent alignment.

### Testing

- Ran a production build with `npm run build`, which completed successfully.
- Launched the dev server and ran an automated Playwright script to capture a screenshot of the app at `http://127.0.0.1:4173/`, which completed and produced an artifact.
- No automated unit tests were present for this area, changes validated by the build and the screenshot check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ffcb6213083219ca012c0449fdb12)